### PR TITLE
update to changes with 3.0

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -1,3 +1,3 @@
 
-require('babel-core/register');
+require('./transpile');
 require('../src/index');

--- a/bin/transpile.js
+++ b/bin/transpile.js
@@ -1,0 +1,16 @@
+//  enable runtime transpilation to use ES6/7 in node
+
+var fs = require('fs');
+var path = require('path');
+
+var babelrc = fs.readFileSync(path.resolve(__dirname, '../node_modules/universal-redux/.babelrc'));
+var config;
+
+try {
+  config = JSON.parse(babelrc);
+} catch (err) {
+  console.error('==>     ERROR: Error parsing your babelrc');
+  console.error(err);
+}
+
+require('babel-core/register')(config);

--- a/package.json
+++ b/package.json
@@ -17,14 +17,14 @@
     "koa-favicon": "^1.2.0",
     "koa-logger": "^1.3.0",
     "koa-static": "^2.0.0",
-    "universal-redux": "git@github.com:bartolkaruza/universal-redux.git#feature/koa-support"
+    "universal-redux": "3.0.1"
   },
   "devDependencies": {
     "concurrently": "1.0.0",
     "react": "^0.14.6",
     "react-dom": "^0.14.6",
-    "react-redux": "4.0.6",
-    "react-router": "2.0.0-rc5",
-    "react-router-redux": "2.1.0"
+    "react-redux": "4.4.0",
+    "react-router": "2.0.0",
+    "react-router-redux": "3.0.0"
   }
 }


### PR DESCRIPTION
koa support has now been merged to master for universal-redux 3.0.1 ... these changes were necessary to get up and running with the example here
